### PR TITLE
Fix recursive rule-checking. Part of https://phab.wish.com/D118493.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,5 +1,10 @@
 History
 -------
+1.0.5
++++++
+released 2020-01-21
+
+- Ensures we check all rulesets so that we can cache their results
 
 1.0.4
 +++++

--- a/business_rules/__init__.py
+++ b/business_rules/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.4'
+__version__ = '1.0.5'
 
 from .engine import run_all
 from .utils import export_rule_data

--- a/business_rules/engine.py
+++ b/business_rules/engine.py
@@ -26,19 +26,24 @@ def run(rule, defined_variables, defined_actions, dry_run=False):
 
 def check_conditions_recursively(conditions, defined_variables):
     keys = list(conditions.keys())
+    # If one condition fails, we can't leave these recursive calls early
+    # since checking the other conditions is when we compute and record important
+    # fields that we want to log (eg. total_gmv_before_refund)
     if keys == ['all']:
         assert len(conditions['all']) >= 1
+        res = True
         for condition in conditions['all']:
             if not check_conditions_recursively(condition, defined_variables):
-                return False
-        return True
+                res = False
+        return res
 
     elif keys == ['any']:
         assert len(conditions['any']) >= 1
+        res = False
         for condition in conditions['any']:
             if check_conditions_recursively(condition, defined_variables):
-                return True
-        return False
+                res = True
+        return res
 
     else:
         # help prevent errors - any and all can only be in the condition dict


### PR DESCRIPTION
Fix for https://phab.wish.com/T167733

Root cause of the issue is that a performance optimization causes us to not check the conditions of every rule and so we don't cache the results related to those conditions, one of them being "total_gmv_before_refund".

More specifically, when checking a group of conditions wrapped by "all", we return immediately when one condition evaluates to False. Same for conditions wrapped by "any". This fix has us check those conditions anyway so that they can be cached and logged.

Testing plan given in the associated Phab diff.